### PR TITLE
Add description saver evaluation

### DIFF
--- a/tel/src/lib.rs
+++ b/tel/src/lib.rs
@@ -8,7 +8,11 @@ mod operators;
 
 pub use description::describe;
 pub use description::evaluate_description;
+pub use description::evaluate_selector_description;
+pub use description::save_to_storage_description;
 pub use description::Description;
+pub use description::ObjectDescription;
+pub use description::SelectorDescription;
 
 pub type ObjectBody = HashMap<String, StorageValue>;
 


### PR DESCRIPTION
Perhaps the description as a name sucks, because it is a bit like a type, a bit like prediction.

This enables users to construct a control flow analysis that checks for used values.