### PR TITLE
Add option to use non-standard cloud or to disable cloud agent

### DIFF
--- a/tel/src/description.rs
+++ b/tel/src/description.rs
@@ -1277,7 +1277,7 @@ mod test_description {
     #[test]
     fn test_save_description() {
         let mut storage = HashMap::new();
-        let mut environment = HashMap::new();
+        let environment = HashMap::new();
 
         apply(
             "test",
@@ -1293,7 +1293,7 @@ mod test_description {
     #[test]
     fn test_save_description2() {
         let mut storage = HashMap::new();
-        let mut environment = HashMap::new();
+        let environment = HashMap::new();
 
         apply(
             "test",

--- a/turbofuro_worker/src/cli.rs
+++ b/turbofuro_worker/src/cli.rs
@@ -10,7 +10,9 @@ FLAGS:
 OPTIONS:
   --config PATH         Runs worker with a configuration read from given PATH
   --token TOKEN         Runs worker with a given device TOKEN
-  --port PORT           Runs HTTP endpoints on a given PORT 
+  --port PORT           Runs HTTP endpoints on a given PORT
+  --disable-agent       Disables cloud agent
+  --cloud URL           Uses a given cloud URL instead of the default one (https://api.turbofuro.com)
 ";
 
 #[derive(Debug)]
@@ -18,6 +20,8 @@ pub struct AppArgs {
     pub token: Option<String>,
     pub port: Option<u16>,
     pub config: Option<std::path::PathBuf>,
+    pub disable_agent: bool,
+    pub cloud_url: Option<String>,
 }
 
 pub fn parse_cli_args() -> Result<AppArgs, pico_args::Error> {
@@ -33,6 +37,8 @@ pub fn parse_cli_args() -> Result<AppArgs, pico_args::Error> {
         token: pargs.opt_value_from_str("--token")?,
         config: pargs.opt_value_from_os_str("--config", parse_path)?,
         port: pargs.opt_value_from_str("--port")?,
+        disable_agent: pargs.contains("--disable-agent"),
+        cloud_url: pargs.opt_value_from_str("--cloud")?,
     };
 
     // It's up to the caller what to do with the remaining arguments.

--- a/turbofuro_worker/src/cloud_agent.rs
+++ b/turbofuro_worker/src/cloud_agent.rs
@@ -66,6 +66,7 @@ pub enum CloudAgentCommand {
 }
 
 pub struct CloudAgent {
+    pub cloud_url: String,
     pub token: String,
     pub environment_resolver: SharedEnvironmentResolver,
     pub module_version_resolver: SharedModuleVersionResolver,
@@ -219,7 +220,8 @@ impl CloudAgent {
                             }
                             CloudAgentCommand::UpdateConfiguration { id: _ } => {
                                 debug!("Cloud agent: Received configuration update command");
-                                let result = fetch_configuration(&self.token).await;
+                                let result =
+                                    fetch_configuration(self.cloud_url.clone(), &self.token).await;
                                 match result {
                                     Ok(configuration) => {
                                         self.configuration_coordinator

--- a/turbofuro_worker/src/cloud_logger.rs
+++ b/turbofuro_worker/src/cloud_logger.rs
@@ -40,9 +40,10 @@ fn check_if_should_report(report: &ExecutionReport, stats: &mut LoggerStats) -> 
 
 pub static RUNS_ACCUMULATOR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-pub fn start_cloud_logger(token: String) -> ExecutionLoggerHandle {
+pub fn start_cloud_logger(token: String, cloud_url: String) -> ExecutionLoggerHandle {
     let client: Client = Client::new();
     let mut log_counter = HashMap::<String, LoggerStats>::new();
+    let url = format!("{}/mission-control/log", cloud_url);
 
     let (sender, mut receiver) = mpsc::channel::<LoggerMessage>(16);
     tokio::spawn(async move {
@@ -74,7 +75,7 @@ pub fn start_cloud_logger(token: String) -> ExecutionLoggerHandle {
 
                     if should_report {
                         match client
-                            .post("https://api.turbofuro.com/mission-control/log")
+                            .post(&url)
                             .header("x-turbofuro-token", &token)
                             .json(&report)
                             .send()

--- a/turbofuro_worker/src/environment_resolver.rs
+++ b/turbofuro_worker/src/environment_resolver.rs
@@ -40,7 +40,7 @@ impl EnvironmentResolver for FileSystemEnvironmentResolver {
     }
 }
 
-pub struct ManagerStorageEnvironmentResolver {
+pub struct CloudEnvironmentResolver {
     pub client: Client,
     pub base_url: String,
 
@@ -48,7 +48,7 @@ pub struct ManagerStorageEnvironmentResolver {
     cache: Cache<String, Environment>,
 }
 
-impl ManagerStorageEnvironmentResolver {
+impl CloudEnvironmentResolver {
     pub fn new(client: Client, base_url: String, token: String) -> Self {
         let cache = Cache::<String, Environment>::new(4);
 
@@ -62,7 +62,7 @@ impl ManagerStorageEnvironmentResolver {
 }
 
 #[async_trait]
-impl EnvironmentResolver for ManagerStorageEnvironmentResolver {
+impl EnvironmentResolver for CloudEnvironmentResolver {
     async fn get_environment(&mut self, id: &str) -> Result<Environment, AppError> {
         if let Some(cached) = self.cache.get(id).await {
             return Ok(cached);


### PR DESCRIPTION
Option to specify URL to the cloud either by CLI option or `TURBOFURO_CLOUD_URL` environment variable. This is useful for multiple environments or separate cloud instances.
Add an option to disable cloud agent in cases where debugging is supposed to be disabled.