### PR TITLE
Make cloud and operator urls customizable

### DIFF
--- a/turbofuro_worker/src/cli.rs
+++ b/turbofuro_worker/src/cli.rs
@@ -5,14 +5,14 @@ USAGE:
   turbofuro_worker [OPTIONS]
 
 FLAGS:
-  -h, --help            Prints help information
+  -h, --help            Prints this help message
 
 OPTIONS:
-  --config PATH         Runs worker with a configuration read from given PATH
-  --token TOKEN         Runs worker with a given device TOKEN
-  --port PORT           Runs HTTP endpoints on a given PORT
-  --disable-agent       Disables cloud agent
-  --cloud URL           Uses a given cloud URL instead of the default one (https://api.turbofuro.com)
+  --config PATH         Runs worker in a offline mode with a configuration read from given PATH
+  --token TOKEN         Runs worker with a given machine TOKEN
+  --port PORT           Runs HTTP server on a given PORT
+  --cloud URL           Uses a given URL as cloud API instead of the default one (https://api.turbofuro.com)
+  --operator URL        Uses a given URL as operator (debugger, stats) instead of the default one (https://operator.turbofuro.com)
 ";
 
 #[derive(Debug)]
@@ -20,8 +20,8 @@ pub struct AppArgs {
     pub token: Option<String>,
     pub port: Option<u16>,
     pub config: Option<std::path::PathBuf>,
-    pub disable_agent: bool,
     pub cloud_url: Option<String>,
+    pub operator_url: Option<String>,
 }
 
 pub fn parse_cli_args() -> Result<AppArgs, pico_args::Error> {
@@ -37,8 +37,8 @@ pub fn parse_cli_args() -> Result<AppArgs, pico_args::Error> {
         token: pargs.opt_value_from_str("--token")?,
         config: pargs.opt_value_from_os_str("--config", parse_path)?,
         port: pargs.opt_value_from_str("--port")?,
-        disable_agent: pargs.contains("--disable-agent"),
         cloud_url: pargs.opt_value_from_str("--cloud")?,
+        operator_url: pargs.opt_value_from_str("--operator")?,
     };
 
     // It's up to the caller what to do with the remaining arguments.

--- a/turbofuro_worker/src/cloud_agent.rs
+++ b/turbofuro_worker/src/cloud_agent.rs
@@ -20,6 +20,7 @@ use crate::{
     environment_resolver::SharedEnvironmentResolver,
     module_version_resolver::SharedModuleVersionResolver,
     worker::{compile_module, get_compiled_module, AppError, ModuleVersion},
+    CloudOptions,
 };
 
 #[derive(Debug)]
@@ -66,8 +67,7 @@ pub enum CloudAgentCommand {
 }
 
 pub struct CloudAgent {
-    pub cloud_url: String,
-    pub token: String,
+    pub cloud_options: CloudOptions,
     pub environment_resolver: SharedEnvironmentResolver,
     pub module_version_resolver: SharedModuleVersionResolver,
     pub global: Arc<Global>,
@@ -93,8 +93,8 @@ impl CloudAgent {
         info!("Cloud agent: Starting {}", name);
 
         let url = Url::parse(&format!(
-            "wss://operator.turbofuro.com/server?token={}",
-            self.token
+            "{}/server?token={}",
+            self.cloud_options.operator_url, self.cloud_options.token
         ))
         .unwrap();
 
@@ -220,8 +220,7 @@ impl CloudAgent {
                             }
                             CloudAgentCommand::UpdateConfiguration { id: _ } => {
                                 debug!("Cloud agent: Received configuration update command");
-                                let result =
-                                    fetch_configuration(self.cloud_url.clone(), &self.token).await;
+                                let result = fetch_configuration(&self.cloud_options).await;
                                 match result {
                                     Ok(configuration) => {
                                         self.configuration_coordinator

--- a/turbofuro_worker/src/config.rs
+++ b/turbofuro_worker/src/config.rs
@@ -4,7 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
-use crate::worker::WorkerError;
+use crate::{worker::WorkerError, CloudOptions};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
@@ -23,15 +23,12 @@ pub struct ModuleSpec {
 
 pub type SharedConfiguration = Arc<Mutex<Configuration>>;
 
-pub async fn fetch_configuration(
-    cloud_url: String,
-    turbofuro_token: &str,
-) -> Result<Configuration, WorkerError> {
-    let url = format!("{}/mission-control/log", cloud_url);
+pub async fn fetch_configuration(options: &CloudOptions) -> Result<Configuration, WorkerError> {
+    let url = format!("{}/mission-control/configuration", options.cloud_url);
 
     let response = reqwest::Client::new()
         .get(url)
-        .header("x-turbofuro-token", turbofuro_token)
+        .header("x-turbofuro-token", options.token.to_owned())
         .header("content-length", 0)
         .send()
         .await
@@ -61,15 +58,12 @@ pub async fn fetch_configuration(
 ///
 /// This is a backup mechanism in case there is an issue with Cloud Agent.
 pub fn run_configuration_fetcher(
-    cloud_url: String,
-    turbofuro_token: String,
+    cloud_options: CloudOptions,
     configuration_coordinator: ConfigurationCoordinator,
 ) {
     tokio::spawn(async move {
         loop {
-            let new_config = fetch_configuration(cloud_url.clone(), &turbofuro_token)
-                .await
-                .unwrap(); // TODO: Error handling
+            let new_config = fetch_configuration(&cloud_options).await.unwrap(); // TODO: Error handling
             {
                 configuration_coordinator
                     .update_configuration(new_config)


### PR DESCRIPTION
Further iteration of https://github.com/turbofuro/turbofuro/pull/5

The operator URL has to be separate because it is using WebSockets so it has a different protocol name. It also uses a different subdomain so that's a bonus reason too.