### PR TITLE
Fix Redis PubSub CPU spikes and disconnection handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "async-compression"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,12 +926,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
 name = "deadpool-postgres"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a24a9d49deefe610b8b60c767a7412e9a931d79a89415cd2d2d71630ca8d7"
 dependencies = [
- "deadpool",
+ "deadpool 0.9.5",
  "log 0.4.21",
  "tokio",
  "tokio-postgres",
@@ -933,11 +950,11 @@ dependencies = [
 
 [[package]]
 name = "deadpool-redis"
-version = "0.12.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1760f60ffc6653b4afd924c5792098d8c00d9a3deb6b3d989eac17949dc422"
+checksum = "7ff315fab2a7a42132352909afc81140d06b8bbfd1414b098ce278e3f95dd1b9"
 dependencies = [
- "deadpool",
+ "deadpool 0.12.1",
  "redis",
 ]
 
@@ -1553,7 +1570,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1636,7 +1653,7 @@ dependencies = [
  "http-body 1.0.0",
  "hyper 1.3.1",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2",
  "tokio",
  "tower",
  "tower-service",
@@ -2595,13 +2612,15 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.23.3"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f49cdc0bb3f412bf8e7d1bd90fe1d9eb10bc5c399ba90973c14662a27b3f8ba"
+checksum = "6472825949c09872e8f2c50bde59fcefc17748b6be5c90fd67cd8b4daca73bfd"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "bytes",
  "combine",
+ "futures",
  "futures-util",
  "itoa",
  "native-tls",
@@ -2609,9 +2628,10 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tokio-native-tls",
+ "tokio-retry",
  "tokio-util",
  "url",
 ]
@@ -3146,16 +3166,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
@@ -3458,7 +3468,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.6",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -3515,10 +3525,21 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand",
- "socket2 0.5.6",
+ "socket2",
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/turbofuro_runtime/Cargo.toml
+++ b/turbofuro_runtime/Cargo.toml
@@ -41,11 +41,12 @@ tokio-postgres = { version = "0.7.10", features = [
 ] }
 postgres-native-tls = "0.5.0"
 native-tls = { version = "0.2.11", features = ["vendored"] }
-redis = { version = "0.23.0", features = [
+redis = { version = "0.25.3", features = [
     "tokio-comp",
     "tokio-native-tls-comp",
+    "connection-manager",
 ] }
-deadpool-redis = "0.12.0"
+deadpool-redis = "0.15.0"
 deadpool-postgres = "0.10.5"
 dashmap = "5.4.0"
 url = "2.4.0"

--- a/turbofuro_runtime/src/actions/postgres.rs
+++ b/turbofuro_runtime/src/actions/postgres.rs
@@ -77,6 +77,21 @@ pub async fn get_connection<'a>(
         }
     })?;
 
+    // Test the connection
+    let conn = pool
+        .get()
+        .await
+        .map_err(|e| ExecutionError::PostgresError {
+            message: e.to_string(),
+            stage: "pool_test".into(),
+        })?;
+    conn.query("SELECT 1", &[])
+        .await
+        .map_err(|e| ExecutionError::PostgresError {
+            message: e.to_string(),
+            stage: "query".into(),
+        })?;
+
     debug!("Created Postgres connection pool: {}", name);
 
     // Put to the registry


### PR DESCRIPTION
Fixes #34 - CPU spikes and disconnections from Redis server.

Also add connection tests for Postgres/Redis pools.

Side note: redis-rs now uses RESP3, so we don't need to use connection pooling anymore? I have left the code as it is, since it seems like deadpool implementation is checking for disconnects via pings, which is a nice thing.

Something to reconsider once we get bored.
