### PR TITLE
Streams and the best HTTP client (in progress)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,12 +1522,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -3826,6 +3826,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 1.0.0",
+ "http-body-util",
  "hyper 1.3.1",
  "jsonwebtoken",
  "log 0.4.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3849,6 +3849,7 @@ dependencies = [
  "tel",
  "tokio",
  "tokio-postgres",
+ "tokio-stream",
  "tokio-util",
  "tower",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +2809,7 @@ dependencies = [
  "js-sys",
  "log 0.4.21",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -2811,10 +2822,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg 0.52.0",
 ]
@@ -3901,6 +3914,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4190,6 +4212,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6425e84e42f7f558478e40ecc2287912cb319f2ca68e5c0bb93c61d4fc63fa17"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/tel/src/description.rs
+++ b/tel/src/description.rs
@@ -2,7 +2,7 @@ use crate::{Expr, Selector, SelectorPart, Spanned, StorageValue, TelError};
 use once_cell::sync::Lazy;
 use serde::Serializer;
 use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, vec};
+use std::{collections::HashMap, fmt::Display, vec};
 use url::Url;
 
 pub type ObjectDescription = HashMap<String, Description>;
@@ -53,6 +53,12 @@ pub enum Description {
     },
     Unknown,
     Any,
+}
+
+impl Display for Description {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_notation())
+    }
 }
 
 impl From<StorageValue> for Description {

--- a/tel/src/lib.rs
+++ b/tel/src/lib.rs
@@ -1,6 +1,7 @@
 use chumsky::{prelude::*, Parser, Stream};
 use serde::Serializer;
 use serde_derive::{Deserialize, Serialize};
+use std::fmt::Display;
 use std::{collections::HashMap, vec};
 
 mod description;
@@ -407,6 +408,47 @@ impl TelError {
             TelError::FunctionNotFound(_) => 7,
             TelError::IndexOutOfBounds { .. } => 8,
             TelError::InvalidIndex { .. } => 9,
+        }
+    }
+}
+
+impl Display for TelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TelError::ParseError { errors } => {
+                for error in errors {
+                    writeln!(f, "{}", error.message)?;
+                }
+                Ok(())
+            }
+            TelError::ConversionError { message, from, to } => {
+                write!(f, "{}: Can't convert {} to {}", message, from, to)
+            }
+            TelError::NotIndexable { message, subject } => {
+                write!(f, "{}: {} is not indexable", message, subject)
+            }
+            TelError::NoAttribute {
+                message,
+                subject,
+                attribute,
+            } => {
+                write!(f, "{}: {} has no attribute {}", message, subject, attribute)
+            }
+            TelError::InvalidSelector { message } => {
+                write!(f, "Invalid selector: {}", message)
+            }
+            TelError::UnsupportedOperation { operation, message } => {
+                write!(f, "Unsupported operation: {}: {}", operation, message)
+            }
+            TelError::FunctionNotFound(_) => {
+                write!(f, "Function not found")
+            }
+            TelError::IndexOutOfBounds { index, max } => {
+                write!(f, "Index out of bounds: {} > {}", index, max)
+            }
+            TelError::InvalidIndex { subject, message } => {
+                write!(f, "Invalid index: {}: {}", subject, message)
+            }
         }
     }
 }

--- a/tel/src/lib.rs
+++ b/tel/src/lib.rs
@@ -49,6 +49,12 @@ where
     }
 }
 
+impl Default for StorageValue {
+    fn default() -> Self {
+        NULL
+    }
+}
+
 impl From<String> for StorageValue {
     fn from(item: String) -> Self {
         StorageValue::String(item)

--- a/tel/src/lib.rs
+++ b/tel/src/lib.rs
@@ -411,7 +411,7 @@ impl TelError {
     }
 }
 
-const NULL: StorageValue = StorageValue::Null(None);
+pub const NULL: StorageValue = StorageValue::Null(None);
 
 /// Op enum for Token parsing
 ///

--- a/turbofuro_runtime/Cargo.toml
+++ b/turbofuro_runtime/Cargo.toml
@@ -25,7 +25,12 @@ tokio = { version = "1.36.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 async-trait = "0.1.60"
-reqwest = { version = "0.12.3", features = ["json", "native-tls-vendored"] }
+reqwest = { version = "0.12.3", features = [
+    "json",
+    "native-tls-vendored",
+    "multipart",
+    "stream",
+] }
 http = "0.2.8"
 async-recursion = "1.0.0"
 serde_derive = "1.0.152"

--- a/turbofuro_runtime/Cargo.toml
+++ b/turbofuro_runtime/Cargo.toml
@@ -68,6 +68,7 @@ postgres = "0.19.7"
 memoize = "0.4.2"
 croner = "2.0.4"
 mustache = "0.9.0"
+http-body-util = "0.1.2"
 
 [dev-dependencies]
 tower = { version = "0.4.13", features = ["util"] }

--- a/turbofuro_runtime/Cargo.toml
+++ b/turbofuro_runtime/Cargo.toml
@@ -69,6 +69,7 @@ memoize = "0.4.2"
 croner = "2.0.4"
 mustache = "0.9.0"
 http-body-util = "0.1.2"
+tokio-stream = "0.1.15"
 
 [dev-dependencies]
 tower = { version = "0.4.13", features = ["util"] }

--- a/turbofuro_runtime/src/actions/form_data.rs
+++ b/turbofuro_runtime/src/actions/form_data.rs
@@ -1,0 +1,171 @@
+use std::{collections::HashMap, pin::Pin};
+
+use axum::body::Bytes;
+use futures_util::Stream;
+use reqwest::multipart::{Form, Part};
+use tel::{describe, Description, StorageValue};
+use tracing::instrument;
+
+use crate::{
+    errors::ExecutionError,
+    evaluations::{eval_optional_param, eval_optional_param_with_default, eval_param},
+    executor::{ExecutionContext, Parameter},
+    resources::{FormDataDraft, Resource},
+};
+
+use super::{as_string, as_u64};
+
+pub fn form_data_draft_resource_not_found() -> ExecutionError {
+    ExecutionError::MissingResource {
+        resource_type: FormDataDraft::get_type().into(),
+    }
+}
+
+#[instrument(level = "trace", skip_all)]
+pub async fn create_form_data<'a>(
+    context: &mut ExecutionContext<'a>,
+    parameters: &Vec<Parameter>,
+    _step_id: &str,
+    _store_as: Option<&str>,
+) -> Result<(), ExecutionError> {
+    let fields_param = eval_optional_param_with_default(
+        "fields",
+        parameters,
+        &context.storage,
+        &context.environment,
+        StorageValue::Object(HashMap::new()),
+    )?;
+
+    let mut form: Form = Form::new();
+
+    match fields_param {
+        StorageValue::Object(object) => {
+            for (key, value) in object {
+                let value = value.to_string().map_err(ExecutionError::from)?;
+                form = form.text(key, value)
+            }
+        }
+        s => {
+            return Err(ExecutionError::ParameterTypeMismatch {
+                name: "headers".to_owned(),
+                expected: Description::new_union(vec![
+                    Description::new_base_type("array"),
+                    Description::new_base_type("object"),
+                ]),
+                actual: describe(s),
+            })
+        }
+    }
+
+    context.resources.form_data.push(FormDataDraft(form));
+
+    Ok(())
+}
+
+type HammerStream = Pin<Box<dyn Stream<Item = Result<Bytes, ExecutionError>> + Send + Sync>>;
+
+struct StreamPart(HammerStream);
+
+impl StreamPart {
+    fn new(stream: HammerStream) -> Self {
+        Self(stream)
+    }
+}
+
+impl From<StreamPart> for reqwest::Body {
+    fn from(val: StreamPart) -> Self {
+        reqwest::Body::wrap_stream(val.0)
+    }
+}
+
+#[instrument(level = "trace", skip_all)]
+pub async fn add_stream_field_to_form_data<'a>(
+    context: &mut ExecutionContext<'a>,
+    parameters: &Vec<Parameter>,
+    _step_id: &str,
+    _store_as: Option<&str>,
+) -> Result<(), ExecutionError> {
+    let name_param = eval_param("name", parameters, &context.storage, &context.environment)?;
+    let name = as_string(name_param, "name")?;
+
+    let size_param =
+        eval_optional_param("size", parameters, &context.storage, &context.environment)?;
+
+    let filename_param = eval_optional_param(
+        "filename",
+        parameters,
+        &context.storage,
+        &context.environment,
+    )?;
+
+    let mime_param =
+        eval_optional_param("mime", parameters, &context.storage, &context.environment)?;
+
+    // Get form data from resources
+    let mut form_data = context
+        .resources
+        .form_data
+        .pop()
+        .ok_or(form_data_draft_resource_not_found())?;
+
+    let stream = context.resources.get_nearest_stream()?;
+
+    let mut part: Part = {
+        if let Some(size_param) = size_param {
+            let size = as_u64(size_param, "size")?;
+            Part::stream_with_length(StreamPart::new(stream), size)
+        } else {
+            Part::stream(StreamPart::new(stream))
+        }
+    };
+
+    if let Some(filename) = filename_param {
+        let filename = as_string(filename, "filename")?;
+        part = part.file_name(filename);
+    }
+
+    if let Some(mime) = mime_param {
+        let mime = as_string(mime, "mime")?;
+        part = part
+            .mime_str(&mime)
+            .map_err(|e| ExecutionError::ParameterInvalid {
+                name: "mime".to_string(),
+                message: e.to_string(),
+            })?;
+    }
+
+    form_data.0 = form_data.0.part(name, part);
+
+    // Store the form data back to resources
+    context.resources.form_data.push(form_data);
+
+    Ok(())
+}
+
+#[instrument(level = "trace", skip_all)]
+pub async fn add_field_to_form_data<'a>(
+    context: &mut ExecutionContext<'a>,
+    parameters: &Vec<Parameter>,
+    _step_id: &str,
+    _store_as: Option<&str>,
+) -> Result<(), ExecutionError> {
+    let name_param = eval_param("name", parameters, &context.storage, &context.environment)?;
+    let name = as_string(name_param, "name")?;
+
+    let value_param = eval_param("value", parameters, &context.storage, &context.environment)?;
+    let value = as_string(value_param, "value")?;
+
+    // Get form data from resources
+    let mut form_data = context
+        .resources
+        .form_data
+        .pop()
+        .ok_or(form_data_draft_resource_not_found())?;
+
+    form_data.0 = form_data.0.text(name, value);
+
+    // Store the form data back to resources
+    context.resources.form_data.push(form_data);
+
+    Ok(())
+}

--- a/turbofuro_runtime/src/actions/http_client.rs
+++ b/turbofuro_runtime/src/actions/http_client.rs
@@ -16,7 +16,7 @@ use crate::{
     evaluations::{eval_optional_param, eval_optional_param_with_default, eval_param},
     executor::{ExecutionContext, Parameter},
     http_utils::decode_text_with_encoding,
-    resources::{HttpRequestToRespond, PendingHttpResponse, Resource},
+    resources::{HttpRequestToRespond, PendingHttpResponseBody, Resource},
 };
 
 use super::{as_string, store_value};
@@ -386,8 +386,8 @@ pub async fn stream_http_request<'a>(
     // Put pending response
     context
         .resources
-        .pending_response
-        .push(PendingHttpResponse::new(response));
+        .pending_response_body
+        .push(PendingHttpResponseBody::new(response));
 
     store_value(
         store_as,
@@ -419,8 +419,8 @@ pub async fn stream_http_request_with_stream<'a>(
     // Put pending response
     context
         .resources
-        .pending_response
-        .push(PendingHttpResponse::new(response));
+        .pending_response_body
+        .push(PendingHttpResponseBody::new(response));
 
     store_value(
         store_as,

--- a/turbofuro_runtime/src/actions/http_server.rs
+++ b/turbofuro_runtime/src/actions/http_server.rs
@@ -48,6 +48,34 @@ pub async fn setup_route<'a>(
 }
 
 #[instrument(level = "debug", skip_all)]
+pub async fn setup_streaming_route<'a>(
+    context: &mut ExecutionContext<'a>,
+    parameters: &Vec<Parameter>,
+    _step_id: &str,
+) -> Result<(), ExecutionError> {
+    let method_param = eval_optional_param_with_default(
+        "method",
+        parameters,
+        &context.storage,
+        &context.environment,
+        "get".into(),
+    )?;
+    let path_param = eval_param("path", parameters, &context.storage, &context.environment)?;
+    let handlers = get_handlers_from_parameters(parameters);
+    {
+        let mut router = context.global.registry.router.lock().await;
+        router.add_streaming_route(
+            method_param.to_string()?,
+            path_param.to_string()?,
+            context.module.id.clone(),
+            handlers,
+        )
+    }
+
+    Ok(())
+}
+
+#[instrument(level = "debug", skip_all)]
 pub async fn respond_with<'a>(
     context: &mut ExecutionContext<'a>,
     parameters: &Vec<Parameter>,

--- a/turbofuro_runtime/src/actions/http_server.rs
+++ b/turbofuro_runtime/src/actions/http_server.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, vec};
 
 use axum::{body::Body, response::Response};
 use tel::{describe, Description, StorageValue};
-use tokio_util::io::ReaderStream;
 use tracing::instrument;
 
 use crate::{

--- a/turbofuro_runtime/src/actions/http_server.rs
+++ b/turbofuro_runtime/src/actions/http_server.rs
@@ -165,7 +165,7 @@ pub async fn respond_with<'a>(
 }
 
 #[instrument(level = "debug", skip_all)]
-pub async fn respond_with_file_stream<'a>(
+pub async fn respond_with_stream<'a>(
     context: &mut ExecutionContext<'a>,
     parameters: &Vec<Parameter>,
     _step_id: &str,
@@ -183,17 +183,7 @@ pub async fn respond_with_file_stream<'a>(
 
     // TODO: Make this more verbose and handle other types by specialized functions
     let response = {
-        let file = context
-            .resources
-            .files
-            .pop()
-            .ok_or(ExecutionError::MissingResource {
-                resource_type: HttpRequestToRespond::get_type().into(),
-            })?;
-
-        // convert the `AsyncRead` into a `Stream`
-        let stream = ReaderStream::new(file.0);
-        // convert the `Stream` into an `axum::body::HttpBody`
+        let stream = context.resources.get_nearest_stream()?;
         let body = Body::from_stream(stream);
 
         let headers_param = eval_optional_param_with_default(

--- a/turbofuro_runtime/src/actions/mod.rs
+++ b/turbofuro_runtime/src/actions/mod.rs
@@ -22,6 +22,7 @@ pub mod postgres;
 pub mod pubsub;
 pub mod redis;
 pub mod time;
+pub mod url;
 pub mod wasm;
 pub mod websocket;
 

--- a/turbofuro_runtime/src/actions/mod.rs
+++ b/turbofuro_runtime/src/actions/mod.rs
@@ -12,6 +12,7 @@ pub mod actors;
 pub mod alarms;
 pub mod convert;
 pub mod crypto;
+pub mod form_data;
 pub mod fs;
 pub mod http_client;
 pub mod http_server;
@@ -50,9 +51,20 @@ pub fn as_string(s: StorageValue, name: &str) -> Result<String, ExecutionError> 
     }
 }
 
-pub fn as_integer(s: StorageValue, name: &str) -> Result<i32, ExecutionError> {
+pub fn as_integer(s: StorageValue, name: &str) -> Result<i64, ExecutionError> {
     match s {
-        StorageValue::Number(f) => Ok(f as i32),
+        StorageValue::Number(f) => Ok(f as i64),
+        s => Err(ExecutionError::ParameterTypeMismatch {
+            name: name.to_owned(),
+            expected: Description::new_base_type("number"),
+            actual: describe(s),
+        }),
+    }
+}
+
+pub fn as_u64(s: StorageValue, name: &str) -> Result<u64, ExecutionError> {
+    match s {
+        StorageValue::Number(f) => Ok(f as u64),
         s => Err(ExecutionError::ParameterTypeMismatch {
             name: name.to_owned(),
             expected: Description::new_base_type("number"),

--- a/turbofuro_runtime/src/actions/url.rs
+++ b/turbofuro_runtime/src/actions/url.rs
@@ -1,0 +1,331 @@
+use std::collections::HashMap;
+
+use tel::{StorageValue, NULL};
+use tracing::instrument;
+use url::Url;
+
+use crate::{
+    errors::ExecutionError,
+    evaluations::{eval_optional_param, eval_optional_param_with_default, eval_param},
+    executor::{ExecutionContext, Parameter},
+};
+
+use super::{as_string, store_value};
+
+/**
+ * https://url.spec.whatwg.org/#url-parsing
+ */
+#[instrument(level = "trace", skip_all)]
+pub async fn parse_url(
+    context: &mut ExecutionContext<'_>,
+    parameters: &Vec<Parameter>,
+    step_id: &str,
+    store_as: Option<&str>,
+) -> Result<(), ExecutionError> {
+    let url_param = eval_param("url", parameters, &context.storage, &context.environment)?;
+    let url = as_string(url_param, "url")?;
+
+    let parsed = Url::parse(&url).map_err(|e| ExecutionError::ParameterInvalid {
+        name: "url".into(),
+        message: e.to_string(),
+    })?;
+
+    let origin: StorageValue = parsed.origin().ascii_serialization().into();
+    let host: StorageValue = parsed.host_str().map(|host| host.into()).unwrap_or(NULL);
+    let path: StorageValue = parsed.path().into();
+    let query: StorageValue = parsed.query().map(|query| query.into()).unwrap_or(NULL);
+    let fragment: StorageValue = parsed
+        .fragment()
+        .map(|fragment| fragment.into())
+        .unwrap_or(NULL);
+    let scheme: StorageValue = parsed.scheme().into();
+    let password: StorageValue = parsed
+        .password()
+        .map(|password| password.into())
+        .unwrap_or(NULL);
+    let username: StorageValue = parsed.username().into(); // TODO: Why is username not an Option?
+    let port: StorageValue = parsed
+        .port()
+        .map(|port| StorageValue::Number(port.into()))
+        .unwrap_or(NULL);
+
+    let mut output: HashMap<String, StorageValue> = HashMap::new();
+    output.insert("host".into(), host);
+    output.insert("origin".into(), origin);
+    output.insert("path".into(), path);
+    output.insert("query".into(), query);
+    output.insert("fragment".into(), fragment);
+    output.insert("scheme".into(), scheme);
+    output.insert("password".into(), password);
+    output.insert("username".into(), username);
+    output.insert("port".into(), port);
+
+    store_value(store_as, context, step_id, StorageValue::Object(output)).await?;
+
+    Ok(())
+}
+
+/**
+ * https://url.spec.whatwg.org/#url-serializing
+ */
+#[instrument(level = "trace", skip_all)]
+pub async fn serialize_url(
+    context: &mut ExecutionContext<'_>,
+    parameters: &Vec<Parameter>,
+    step_id: &str,
+    store_as: Option<&str>,
+) -> Result<(), ExecutionError> {
+    let host_param = eval_param("host", parameters, &context.storage, &context.environment)?;
+    let host = as_string(host_param, "host")?;
+
+    let scheme_param: StorageValue = eval_optional_param_with_default(
+        "scheme",
+        parameters,
+        &context.storage,
+        &context.environment,
+        StorageValue::String("https".into()),
+    )?;
+    let scheme = as_string(scheme_param, "scheme")?;
+    let port_param =
+        eval_optional_param("port", parameters, &context.storage, &context.environment)?;
+
+    let path_param =
+        eval_optional_param("path", parameters, &context.storage, &context.environment)?;
+    let query_param =
+        eval_optional_param("query", parameters, &context.storage, &context.environment)?;
+    let fragment = eval_optional_param(
+        "fragment",
+        parameters,
+        &context.storage,
+        &context.environment,
+    )?;
+    let username = eval_optional_param(
+        "username",
+        parameters,
+        &context.storage,
+        &context.environment,
+    )?;
+    let password = eval_optional_param(
+        "password",
+        parameters,
+        &context.storage,
+        &context.environment,
+    )?;
+
+    // Construct the URL
+    let mut url = Url::parse(&format!("{}://{}", scheme, host)).map_err(|e| {
+        ExecutionError::ParameterInvalid {
+            name: "host".into(),
+            message: e.to_string(),
+        }
+    })?;
+
+    if let Some(port_value) = port_param {
+        let port = match port_value {
+            StorageValue::Number(port) => {
+                u16::try_from(port as i64).map_err(|_e| ExecutionError::ParameterInvalid {
+                    name: "port".into(),
+                    message: "Port could not be parsed".into(),
+                })?
+            }
+            StorageValue::String(port) => {
+                port.parse::<u16>()
+                    .map_err(|_e| ExecutionError::ParameterInvalid {
+                        name: "port".into(),
+                        message: "Port could not be parsed".into(),
+                    })?
+            }
+            _ => {
+                return Err(ExecutionError::ParameterInvalid {
+                    name: "port".into(),
+                    message: "Port must be a number between 0 and".into(),
+                });
+            }
+        };
+        url.set_port(Some(port))
+            .map_err(|_e| ExecutionError::StateInvalid {
+                message: "Port could not be set".into(),
+                subject: "url".into(),
+                inner: "port".into(), // TODO: Errors
+            })?;
+    }
+
+    if let Some(path) = path_param {
+        let path = as_string(path, "path")?;
+        url.set_path(&path);
+    }
+
+    if let Some(query) = query_param {
+        let query = as_string(query, "query")?;
+        url.set_query(Some(&query));
+    }
+
+    if let Some(fragment) = fragment {
+        let fragment = as_string(fragment, "fragment")?;
+        url.set_fragment(Some(&fragment));
+    }
+
+    if let Some(username) = username {
+        let username = as_string(username, "username")?;
+        url.set_username(&username)
+            .map_err(|_e| ExecutionError::StateInvalid {
+                message: "Username could not be set".into(),
+                subject: "url".into(),
+                inner: "username".into(), // TODO: Errors
+            })?;
+    }
+
+    if let Some(password) = password {
+        let password = as_string(password, "password")?;
+        url.set_password(Some(&password))
+            .map_err(|_e| ExecutionError::StateInvalid {
+                message: "Password could not be set".into(),
+                subject: "url".into(),
+                inner: "password".into(), // TODO: Errors
+            })?;
+    }
+
+    store_value(store_as, context, step_id, StorageValue::String(url.into())).await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test_url {
+    use crate::{evaluations::eval, executor::ExecutionTest};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parse_basic() {
+        let mut t = ExecutionTest::default();
+        let mut context = t.get_context();
+
+        parse_url(
+            &mut context,
+            &vec![Parameter::tel(
+                "url",
+                "\"https://example.com/test?query=1#fragment\"",
+            )],
+            "test",
+            Some("parsed"),
+        )
+        .await
+        .unwrap();
+
+        let parsed = eval("parsed", &context.storage, &context.environment).unwrap();
+        assert_eq!(
+            parsed,
+            StorageValue::Object(
+                vec![
+                    ("origin".to_owned(), "https://example.com".into()),
+                    ("host".to_owned(), "example.com".into()),
+                    ("path".to_owned(), "/test".into()),
+                    (
+                        "query".to_owned(),
+                        "query=1".into() // TODO: Should this be a hashmap?
+                    ),
+                    ("fragment".to_owned(), "fragment".into()),
+                    ("scheme".to_owned(), "https".into()),
+                    ("password".to_owned(), NULL),
+                    ("username".to_owned(), "".into()),
+                    ("port".to_owned(), NULL),
+                ]
+                .into_iter()
+                .collect()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_complex() {
+        let mut t = ExecutionTest::default();
+        let mut context = t.get_context();
+
+        parse_url(
+            &mut context,
+            &vec![Parameter::tel(
+                "url",
+                "\"redis://username:pass@localhost:6379/wow\"",
+            )],
+            "test",
+            Some("parsed"),
+        )
+        .await
+        .unwrap();
+
+        let parsed = eval("parsed", &context.storage, &context.environment).unwrap();
+        assert_eq!(
+            parsed,
+            StorageValue::Object(
+                vec![
+                    ("origin".to_owned(), "null".into()),
+                    ("host".to_owned(), "localhost".into()),
+                    ("path".to_owned(), StorageValue::String("/wow".to_owned())),
+                    ("query".to_owned(), NULL),
+                    ("fragment".to_owned(), NULL),
+                    ("scheme".to_owned(), "redis".into()),
+                    ("password".to_owned(), "pass".into()),
+                    ("username".to_owned(), "username".into()),
+                    ("port".to_owned(), StorageValue::Number(6379.0)),
+                ]
+                .into_iter()
+                .collect()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_serialize() {
+        let mut t = ExecutionTest::default();
+        let mut context = t.get_context();
+
+        serialize_url(
+            &mut context,
+            &vec![
+                Parameter::tel("host", "\"example.org\""),
+                Parameter::tel("path", "\"/test\""),
+                Parameter::tel("query", "\"query=1\""),
+                Parameter::tel("fragment", "\"fragment\""),
+            ],
+            "test",
+            Some("url"),
+        )
+        .await
+        .unwrap();
+
+        let parsed = eval("url", &context.storage, &context.environment).unwrap();
+        assert_eq!(
+            parsed,
+            StorageValue::String("https://example.org/test?query=1#fragment".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_serialize_complex() {
+        let mut t = ExecutionTest::default();
+        let mut context = t.get_context();
+
+        serialize_url(
+            &mut context,
+            &vec![
+                Parameter::tel("host", "\"localhost\""),
+                Parameter::tel("scheme", "\"redis\""),
+                Parameter::tel("path", "\"/wow\""),
+                Parameter::tel("username", "\"username\""),
+                Parameter::tel("password", "\"pass\""),
+                Parameter::tel("port", "6379"),
+            ],
+            "test",
+            Some("url"),
+        )
+        .await
+        .unwrap();
+
+        let parsed = eval("url", &context.storage, &context.environment).unwrap();
+        assert_eq!(
+            parsed,
+            StorageValue::String("redis://username:pass@localhost:6379/wow".to_owned())
+        );
+    }
+}

--- a/turbofuro_runtime/src/errors.rs
+++ b/turbofuro_runtime/src/errors.rs
@@ -1,3 +1,5 @@
+use std::{error::Error, fmt::Display};
+
 use redis::RedisError;
 use serde::{Deserialize, Serialize};
 use tel::{Description, StorageValue, TelError};
@@ -82,6 +84,122 @@ pub enum ExecutionError {
     WasmError {
         message: String,
     },
+}
+
+impl Display for ExecutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExecutionError::Custom { value } => {
+                write!(f, "Custom error: {:?}", value)
+            }
+            ExecutionError::Tel { error } => {
+                write!(f, "Tel error: {}", error)
+            }
+            ExecutionError::MissingParameter { name } => {
+                write!(f, "Missing parameter: {}", name)
+            }
+            ExecutionError::ParameterTypeMismatch {
+                name,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "Parameter type mismatch: {} expected: {} actual: {}",
+                    name, expected, actual
+                )
+            }
+            ExecutionError::ParameterInvalid { name, message } => {
+                write!(f, "Parameter invalid: {} message: {}", name, message)
+            }
+            ExecutionError::Unknown { message } => {
+                write!(f, "Unknown error: {}", message)
+            }
+            ExecutionError::StateInvalid {
+                message,
+                subject,
+                inner,
+            } => {
+                write!(
+                    f,
+                    "State invalid: {} subject: {} inner: {}",
+                    message, subject, inner
+                )
+            }
+            ExecutionError::MissingResource { resource_type } => {
+                write!(f, "Missing resource: {}", resource_type)
+            }
+            ExecutionError::Continue => {
+                write!(f, "Continue")
+            }
+            ExecutionError::Break => {
+                write!(f, "Break")
+            }
+            ExecutionError::Return { value } => {
+                write!(f, "Return: {:?}", value)
+            }
+            ExecutionError::HandlerNotFound { name } => {
+                write!(f, "Handler not found: {}", name)
+            }
+            ExecutionError::FunctionNotFound { id } => {
+                write!(f, "Function not found: {}", id)
+            }
+            ExecutionError::ModuleVersionNotFound { id } => {
+                write!(f, "Module version not found: {}", id)
+            }
+            ExecutionError::UnresolvedImport { import_name } => {
+                write!(f, "Unresolved import: {}", import_name)
+            }
+            ExecutionError::Unsupported { message } => {
+                write!(f, "Unsupported: {}", message)
+            }
+            ExecutionError::SerializationFailed {
+                message,
+                breadcrumbs,
+                inner,
+            } => {
+                write!(
+                    f,
+                    "Serialization failed: {} breadcrumbs: {} inner: {}",
+                    message, breadcrumbs, inner
+                )
+            }
+            ExecutionError::JwtDecodingFailed { message } => {
+                write!(f, "JWT decoding failed: {}", message)
+            }
+            ExecutionError::ActorCommandFailed { message } => {
+                write!(f, "Actor command failed: {}", message)
+            }
+            ExecutionError::PostgresError { message, stage } => {
+                write!(f, "Postgres error: {} stage: {}", message, stage)
+            }
+            ExecutionError::RedisError { message } => {
+                write!(f, "Redis error: {}", message)
+            }
+            ExecutionError::IoError { message } => {
+                write!(f, "IO error: {}", message)
+            }
+            ExecutionError::WasmError { message } => {
+                write!(f, "Wasm error: {}", message)
+            }
+        }
+    }
+}
+
+impl Error for ExecutionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
+    }
+
+    fn cause(&self) -> Option<&dyn Error> {
+        self.source()
+    }
+
+    // fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {}
 }
 
 impl From<TelError> for ExecutionError {

--- a/turbofuro_runtime/src/executor.rs
+++ b/turbofuro_runtime/src/executor.rs
@@ -31,8 +31,11 @@ use crate::actions::convert;
 use crate::actions::crypto;
 use crate::actions::fs;
 use crate::actions::http_client::send_http_request;
+use crate::actions::http_client::send_http_request_with_stream;
+use crate::actions::http_client::stream_http_request;
+use crate::actions::http_client::stream_http_request_with_stream;
 use crate::actions::http_server::respond_with;
-use crate::actions::http_server::respond_with_file_stream;
+use crate::actions::http_server::respond_with_stream;
 use crate::actions::http_server::setup_route;
 use crate::actions::kv;
 use crate::actions::mustache;
@@ -818,8 +821,11 @@ async fn execute_native<'a>(
     match native_id {
         "wasm/run_wasi" => wasm::run_wasi(context, parameters, step_id, store_as).await?,
         "fs/open" => fs::open_file(context, parameters, step_id).await?,
-        "fs/write_string" => fs::write_string(context, parameters, step_id).await?,
-        "fs/read_to_string" => fs::read_to_string(context, parameters, step_id, store_as).await?,
+        "fs/write_stream" => fs::write_stream(context, step_id).await?,
+        "fs/write_string" => fs::simple_write_string(context, parameters, step_id).await?,
+        "fs/read_to_string" => {
+            fs::simple_read_to_string(context, parameters, step_id, store_as).await?
+        }
         "alarms/set_alarm" => alarms::set_alarm(context, parameters, step_id).await?,
         "alarms/set_interval" => alarms::set_interval(context, parameters, step_id).await?,
         "alarms/cancel" => alarms::cancel_alarm(context, parameters, step_id).await?,
@@ -847,10 +853,19 @@ async fn execute_native<'a>(
         "url/parse" => url::parse_url(context, parameters, step_id, store_as).await?,
         "url/serialize" => url::serialize_url(context, parameters, step_id, store_as).await?,
         "http_client/request" => send_http_request(context, parameters, step_id, store_as).await?,
+        "http_client/request_with_stream" => {
+            send_http_request_with_stream(context, parameters, step_id, store_as).await?
+        }
+        "http_client/stream_request" => {
+            stream_http_request(context, parameters, step_id, store_as).await?
+        }
+        "http_client/stream_request_with_stream" => {
+            stream_http_request_with_stream(context, parameters, step_id, store_as).await?
+        }
         "http_server/setup_route" => setup_route(context, parameters, step_id).await?,
         "http_server/respond_with" => respond_with(context, parameters, step_id).await?,
-        "http_server/respond_with_file_stream" => {
-            respond_with_file_stream(context, parameters, step_id).await?
+        "http_server/respond_with_stream" => {
+            respond_with_stream(context, parameters, step_id).await?
         }
         "postgres/get_connection" => postgres::get_connection(context, parameters, step_id).await?,
         "postgres/query_one" => postgres::query_one(context, parameters, step_id, store_as).await?,

--- a/turbofuro_runtime/src/executor.rs
+++ b/turbofuro_runtime/src/executor.rs
@@ -29,15 +29,10 @@ use crate::actions::actors;
 use crate::actions::alarms;
 use crate::actions::convert;
 use crate::actions::crypto;
+use crate::actions::form_data;
 use crate::actions::fs;
-use crate::actions::http_client::send_http_request;
-use crate::actions::http_client::send_http_request_with_stream;
-use crate::actions::http_client::stream_http_request;
-use crate::actions::http_client::stream_http_request_with_stream;
-use crate::actions::http_server::respond_with;
-use crate::actions::http_server::respond_with_stream;
-use crate::actions::http_server::setup_route;
-use crate::actions::http_server::setup_streaming_route;
+use crate::actions::http_client;
+use crate::actions::http_server;
 use crate::actions::kv;
 use crate::actions::mustache;
 use crate::actions::os;
@@ -825,7 +820,7 @@ async fn execute_native<'a>(
 
     match native_id {
         "wasm/run_wasi" => wasm::run_wasi(context, parameters, step_id, store_as).await?,
-        "fs/open" => fs::open_file(context, parameters, step_id).await?,
+        "fs/open" => fs::open_file(context, parameters, step_id, store_as).await?,
         "fs/write_stream" => fs::write_stream(context, step_id).await?,
         "fs/write_string" => fs::simple_write_string(context, parameters, step_id).await?,
         "fs/read_to_string" => {
@@ -859,23 +854,46 @@ async fn execute_native<'a>(
         }
         "url/parse" => url::parse_url(context, parameters, step_id, store_as).await?,
         "url/serialize" => url::serialize_url(context, parameters, step_id, store_as).await?,
-        "http_client/request" => send_http_request(context, parameters, step_id, store_as).await?,
+        "http_client/request" => {
+            http_client::send_http_request(context, parameters, step_id, store_as).await?
+        }
         "http_client/request_with_stream" => {
-            send_http_request_with_stream(context, parameters, step_id, store_as).await?
+            http_client::send_http_request_with_stream(context, parameters, step_id, store_as)
+                .await?
+        }
+        "http_client/request_with_form_data" => {
+            http_client::send_http_request_with_form_data(context, parameters, step_id, store_as)
+                .await?
         }
         "http_client/stream_request" => {
-            stream_http_request(context, parameters, step_id, store_as).await?
+            http_client::stream_http_request(context, parameters, step_id, store_as).await?
         }
         "http_client/stream_request_with_stream" => {
-            stream_http_request_with_stream(context, parameters, step_id, store_as).await?
+            http_client::stream_http_request_with_stream(context, parameters, step_id, store_as)
+                .await?
         }
-        "http_server/setup_route" => setup_route(context, parameters, step_id).await?,
+        "http_client/stream_request_with_form_data" => {
+            http_client::stream_http_request_with_form_data(context, parameters, step_id, store_as)
+                .await?
+        }
+        "form_data/create" => {
+            form_data::create_form_data(context, parameters, step_id, store_as).await?
+        }
+        "form_data/add_stream_field" => {
+            form_data::add_stream_field_to_form_data(context, parameters, step_id, store_as).await?
+        }
+        "form_data/add_field" => {
+            form_data::add_field_to_form_data(context, parameters, step_id, store_as).await?
+        }
+        "http_server/setup_route" => http_server::setup_route(context, parameters, step_id).await?,
         "http_server/setup_streaming_route" => {
-            setup_streaming_route(context, parameters, step_id).await?
+            http_server::setup_streaming_route(context, parameters, step_id).await?
         }
-        "http_server/respond_with" => respond_with(context, parameters, step_id).await?,
+        "http_server/respond_with" => {
+            http_server::respond_with(context, parameters, step_id).await?
+        }
         "http_server/respond_with_stream" => {
-            respond_with_stream(context, parameters, step_id).await?
+            http_server::respond_with_stream(context, parameters, step_id).await?
         }
         "postgres/get_connection" => postgres::get_connection(context, parameters, step_id).await?,
         "postgres/query_one" => postgres::query_one(context, parameters, step_id, store_as).await?,

--- a/turbofuro_runtime/src/executor.rs
+++ b/turbofuro_runtime/src/executor.rs
@@ -30,7 +30,7 @@ use crate::actions::alarms;
 use crate::actions::convert;
 use crate::actions::crypto;
 use crate::actions::fs;
-use crate::actions::http_client::http_request;
+use crate::actions::http_client::send_http_request;
 use crate::actions::http_server::respond_with;
 use crate::actions::http_server::respond_with_file_stream;
 use crate::actions::http_server::setup_route;
@@ -41,6 +41,7 @@ use crate::actions::postgres;
 use crate::actions::pubsub;
 use crate::actions::redis;
 use crate::actions::time;
+use crate::actions::url;
 use crate::actions::wasm;
 use crate::actions::websocket;
 use crate::debug::DebugMessage;
@@ -843,7 +844,9 @@ async fn execute_native<'a>(
         "actors/check_actor_exists" => {
             actors::check_actor_exists(context, parameters, step_id, store_as).await?
         }
-        "http_client/request" => http_request(context, parameters, step_id, store_as).await?,
+        "url/parse" => url::parse_url(context, parameters, step_id, store_as).await?,
+        "url/serialize" => url::serialize_url(context, parameters, step_id, store_as).await?,
+        "http_client/request" => send_http_request(context, parameters, step_id, store_as).await?,
         "http_server/setup_route" => setup_route(context, parameters, step_id).await?,
         "http_server/respond_with" => respond_with(context, parameters, step_id).await?,
         "http_server/respond_with_file_stream" => {

--- a/turbofuro_runtime/src/executor.rs
+++ b/turbofuro_runtime/src/executor.rs
@@ -37,6 +37,7 @@ use crate::actions::http_client::stream_http_request_with_stream;
 use crate::actions::http_server::respond_with;
 use crate::actions::http_server::respond_with_stream;
 use crate::actions::http_server::setup_route;
+use crate::actions::http_server::setup_streaming_route;
 use crate::actions::kv;
 use crate::actions::mustache;
 use crate::actions::os;
@@ -869,6 +870,9 @@ async fn execute_native<'a>(
             stream_http_request_with_stream(context, parameters, step_id, store_as).await?
         }
         "http_server/setup_route" => setup_route(context, parameters, step_id).await?,
+        "http_server/setup_streaming_route" => {
+            setup_streaming_route(context, parameters, step_id).await?
+        }
         "http_server/respond_with" => respond_with(context, parameters, step_id).await?,
         "http_server/respond_with_stream" => {
             respond_with_stream(context, parameters, step_id).await?

--- a/turbofuro_runtime/src/resources.rs
+++ b/turbofuro_runtime/src/resources.rs
@@ -1,12 +1,10 @@
-use axum::{body::Bytes, extract::ws::Message, response::Response, BoxError};
+use axum::{body::Bytes, extract::ws::Message, response::Response};
 use dashmap::DashMap;
 use futures_util::stream::Stream;
-use futures_util::{StreamExt, TryStream, TryStreamExt};
+use futures_util::TryStreamExt;
 use serde_derive::{Deserialize, Serialize};
 use std::pin::Pin;
-use std::task::{Context, Poll};
 use tel::StorageValue;
-use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 
 use std::{

--- a/turbofuro_runtime/src/resources.rs
+++ b/turbofuro_runtime/src/resources.rs
@@ -6,6 +6,7 @@ use axum::{
 use dashmap::DashMap;
 use futures_util::stream::Stream;
 use futures_util::{StreamExt, TryStreamExt};
+use reqwest::multipart::Form;
 use serde_derive::{Deserialize, Serialize};
 use std::pin::Pin;
 use tel::StorageValue;
@@ -28,6 +29,7 @@ const REDIS_CONNECTION_RESOURCE_TYPE: &str = "redis_connection";
 const HTTP_REQUEST_RESOURCE_TYPE: &str = "http_request";
 const PENDING_HTTP_RESPONSE_TYPE: &str = "pending_http_response";
 const PENDING_HTTP_REQUEST_TYPE: &str = "pending_http_request";
+const FORM_DATA_DRAFT_TYPE: &str = "form_data_draft";
 const ACTOR_LINK_TYPE: &str = "actor_link";
 const CANCELLATION: &str = "cancellation";
 const FILE_HANDLE: &str = "file_handle";
@@ -273,6 +275,21 @@ impl Resource for PendingHttpRequestBody {
     }
 }
 
+#[derive(Debug)]
+pub struct FormDataDraft(pub Form);
+
+impl FormDataDraft {
+    pub fn new(form: Form) -> Self {
+        Self(form)
+    }
+}
+
+impl Resource for FormDataDraft {
+    fn get_type() -> &'static str {
+        FORM_DATA_DRAFT_TYPE
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ResourceRegistry {
     pub redis_pools: DashMap<String, RedisPool>,
@@ -289,6 +306,7 @@ pub struct ActorResources {
     pub files: Vec<FileHandle>,
     pub pending_response_body: Vec<PendingHttpResponseBody>,
     pub pending_request_body: Vec<PendingHttpRequestBody>,
+    pub form_data: Vec<FormDataDraft>,
 }
 
 pub struct PendingHttpRequestStream(pub BodyDataStream);


### PR DESCRIPTION
#26 #27 #36

1. Added form parameter to handle `application/x-www-form-urlencoded` payloads
2. Added streaming HTTP client
3. Added request/reply model for actor interactions, something similar to handle_call in Elixir GenServers
4. Added streaming HTTP routes
5. Added form data
6. Added file metadata to acquire size for proper form data handling

You can now:
1. Download huge files to your worker
2. Proxy requests to other services
3. Serve static files without specific setup
4. Upload files with form data

![image](https://github.com/turbofuro/turbofuro/assets/11592159/72340def-c9d0-4d75-a0a5-26bf5d444aed)
